### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,3 +108,8 @@ SENSITIVE_TOOLS = [
     "your_tool_function"  # Add your tool name here if it requires confirmation
 ]
 ```
+
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/higress-group-higress-ops-mcp-server).
+


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/higress-group-higress-ops-mcp-server).